### PR TITLE
Loosen base dependency to allow ghc 7.6

### DIFF
--- a/IPv6Addr.cabal
+++ b/IPv6Addr.cabal
@@ -21,7 +21,7 @@ library
   exposed-modules:     Text.IPv6Addr, Text.IPv6Addr.Types, Text.IPv6Addr.Manip, Text.IPv6Addr.Internal
   -- other-modules:
   other-extensions:    OverloadedStrings
-  build-depends:       base >=4.6 && <4.9, text >=1.2 && <1.3, iproute >=1.3 && <1.4, network >=2.6 && <2.7, random >=1.1 && <1.2, attoparsec >=0.12 && <0.13, network-info >=0.2 && <0.3
+  build-depends:       base >=4.6 && <4.9, text >=1.1 && <1.3, iproute >=1.3 && <1.4, network >=2.5 && <2.7, random >=1.0 && <1.2, attoparsec >=0.12 && <0.13, network-info >=0.2 && <0.3
   -- hs-source-dirs:
   default-language:    Haskell2010
 

--- a/IPv6Addr.cabal
+++ b/IPv6Addr.cabal
@@ -19,10 +19,10 @@ Source-Repository head
 
 library
   exposed-modules:     Text.IPv6Addr, Text.IPv6Addr.Types, Text.IPv6Addr.Manip, Text.IPv6Addr.Internal
-  -- other-modules:       
+  -- other-modules:
   other-extensions:    OverloadedStrings
-  build-depends:       base >=4.7 && <4.9, text >=1.2 && <1.3, iproute >=1.3 && <1.4, network >=2.6 && <2.7, random >=1.1 && <1.2, attoparsec >=0.12 && <0.13, network-info >=0.2 && <0.3
-  -- hs-source-dirs:      
+  build-depends:       base >=4.6 && <4.9, text >=1.2 && <1.3, iproute >=1.3 && <1.4, network >=2.6 && <2.7, random >=1.1 && <1.2, attoparsec >=0.12 && <0.13, network-info >=0.2 && <0.3
+  -- hs-source-dirs:
   default-language:    Haskell2010
 
 Test-Suite tests


### PR DESCRIPTION
A base lower bound was added that turned out to be too restrictive and excludes ghc 7.6. I've loosed this and confirmed that it builds and that tests pass.
