### PR TITLE
Fix lower bound on `base`

### DIFF
--- a/IPv6Addr.cabal
+++ b/IPv6Addr.cabal
@@ -20,7 +20,7 @@ Source-Repository head
 library
   exposed-modules:  Text.IPv6Addr, Text.IPv6Addr.Types, Text.IPv6Addr.Manip, Text.IPv6Addr.Internal
   other-extensions: OverloadedStrings
-  build-depends:    base >=4.6 && <5
+  build-depends:    base >=4.8 && <5
                   , text >=1.1 && <1.3
                   , iproute >=1.3 && <1.8
                   , network >=2.5 && <2.7


### PR DESCRIPTION
As this currently doesn't build with GHC 7.8.4 yet (and the Travis config doesn't appear to test against GHC 7.8.4 either)

```
Configuring component lib from IPv6Addr-0.6.3
Preprocessing library IPv6Addr-0.6.3...
[1 of 4] Compiling Text.IPv6Addr.Types ( Text/IPv6Addr/Types.hs, /tmp/matrix-worker/1482774573/dist-newstyle/build/x86_64-linux/ghc-7.8.4/IPv6Addr-0.6.3/build/Text/IPv6Addr/Types.o )
[2 of 4] Compiling Text.IPv6Addr.Internal ( Text/IPv6Addr/Internal.hs, /tmp/matrix-worker/1482774573/dist-newstyle/build/x86_64-linux/ghc-7.8.4/IPv6Addr-0.6.3/build/Text/IPv6Addr/Internal.o )

Text/IPv6Addr/Internal.hs:256:34:
    Not in scope: ‘<$>’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid),
      ‘<|>’ (imported from Control.Applicative),
      ‘<?>’ (imported from Data.Attoparsec.Text)

Text/IPv6Addr/Internal.hs:262:26:
    Not in scope: ‘<*’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘*’ (imported from Prelude),
      ‘**’ (imported from Prelude)

Text/IPv6Addr/Internal.hs:263:26:
    Not in scope: ‘<*’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘*’ (imported from Prelude),
      ‘**’ (imported from Prelude)

Text/IPv6Addr/Internal.hs:264:26:
    Not in scope: ‘<*’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘*’ (imported from Prelude),
      ‘**’ (imported from Prelude)

Text/IPv6Addr/Internal.hs:265:26:
    Not in scope: ‘<*’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘*’ (imported from Prelude),
      ‘**’ (imported from Prelude)

Text/IPv6Addr/Internal.hs:266:26:
    Not in scope: ‘<*’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘*’ (imported from Prelude),
      ‘**’ (imported from Prelude)

Text/IPv6Addr/Internal.hs:283:20:
    Not in scope: ‘<*’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘*’ (imported from Prelude),
      ‘**’ (imported from Prelude)

Text/IPv6Addr/Internal.hs:285:20:
    Not in scope: ‘<*’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘*’ (imported from Prelude),
      ‘**’ (imported from Prelude)

Text/IPv6Addr/Internal.hs:287:20:
    Not in scope: ‘<*’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘*’ (imported from Prelude),
      ‘**’ (imported from Prelude)
```