### PR TITLE
Fix upper bound for random

### DIFF
--- a/IPv6Addr.cabal
+++ b/IPv6Addr.cabal
@@ -26,7 +26,7 @@ library
                   , text         >=1.1 && < 1.3
                   , iproute      >=1.3 && < 1.8
                   , network      >=2.5 && < 4
-                  , random       >=1.0 && <= 1.2
+                  , random       >=1.0 && < 1.3
                   , attoparsec   >=0.12 && < 0.14
                   , aeson        >= 0.8.0.2 && < 1.6
                   , network-info >=0.2 && <=0.3


### PR DESCRIPTION
This PR fixes bounds for random-1.2.0

 For some reason cabal will not evaluate this to `true`: `1.2.0 <= 1.2`

If possible a new revision on hackage would be awesome, since it is blocking commercialhaskell/stackage#5474